### PR TITLE
Fix StorageKeys.service_and_creds so it properly parses keys with multiple credentials

### DIFF
--- a/lib/xcflushd/storage_keys.rb
+++ b/lib/xcflushd/storage_keys.rb
@@ -80,10 +80,12 @@ module Xcflushd
       # Returns an array of size 2 with a service and the credentials encoded
       # given a key marked as 'to be flushed' and its suffix.
       def service_and_creds(key_to_flush, suffix)
-        escaped_service, escaped_creds =
-            key_to_flush.sub("#{KEY_TO_FLUSH_PREFIX}#{REPORT_KEY_PREFIX}", '')
-                        .sub(suffix, '')
-                        .split(/(?<!\\),/)
+        split_key = key_to_flush.sub("#{KEY_TO_FLUSH_PREFIX}#{REPORT_KEY_PREFIX}", '')
+                                .sub(suffix, '')
+                                .split(/(?<!\\),/)
+
+        escaped_service = split_key.first
+        escaped_creds = split_key[1..-1].join(','.freeze)
 
         # escaped_service is a string with 'service_id:' followed by the escaped
         # service ID. escaped_creds starts with 'credentials:' and is followed

--- a/spec/storage_keys_spec.rb
+++ b/spec/storage_keys_spec.rb
@@ -137,9 +137,6 @@ module Xcflushd
 
     describe '.service_and_creds' do
       let(:service_id) { 'a_service_id' }
-      let(:credentials) do
-        Credentials.new(user_key: 'a,user:key') # ':' and ',' need to be escaped
-      end
       let(:suffix) { 'a_suffix' }
 
       # Based on the 3 lets defined above
@@ -151,9 +148,26 @@ module Xcflushd
             suffix
       end
 
-      it 'returns an array with the service ID and credentials encoded in the key' do
-        expect(subject.service_and_creds(encoded_key, suffix))
-            .to eq [service_id, credentials]
+      context 'when the key contains just one credential' do
+        let(:credentials) do
+          Credentials.new(user_key: 'a,user:key') # ':' and ',' need to be escaped
+        end
+
+        it 'returns an array with the service ID and credentials encoded in the key' do
+          expect(subject.service_and_creds(encoded_key, suffix))
+              .to eq [service_id, credentials]
+        end
+      end
+
+      context 'when the key contains several credentials' do
+        let(:credentials) do
+          Credentials.new(app_id: 'an,app:id', app_key: 'a_key')
+        end
+
+        it 'returns an array with the service ID and credentials encoded in the key' do
+          expect(subject.service_and_creds(encoded_key, suffix))
+              .to eq [service_id, credentials]
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes a bug. For keys that contain multiple credentials, for example, an app_id and an app_key, `.service_and_creds` was just returning the first one.