### PR TITLE
Better handling of signals

### DIFF
--- a/lib/xcflushd/runner.rb
+++ b/lib/xcflushd/runner.rb
@@ -157,8 +157,12 @@ module Xcflushd
 
       def setup_sighandlers
         @exit = false
-        Signal.trap('EXIT') { @exit = true }
-        Signal.trap('INT') { @exit = true }
+        ['HUP', 'USR1', 'USR2'].each do |sig|
+          Signal.trap(sig, "SIG_IGN")
+        end
+        ['EXIT', 'TERM', 'INT'].each do |sig|
+          Signal.trap(sig) { @exit = true }
+        end
       end
     end
   end

--- a/lib/xcflushd/runner.rb
+++ b/lib/xcflushd/runner.rb
@@ -97,6 +97,8 @@ module Xcflushd
           end
         end
         @logger.info('Exiting')
+      rescue SignalException => e
+        @logger.fatal("Received unhandled signal #{e.cause}, shutting down")
       rescue Exception => e
         @logger.fatal("Unhandled exception #{e.class}, shutting down: #{e.cause} - #{e}")
       ensure


### PR DESCRIPTION
This will cause xcflushd to not terminate on `SIGHUP`, `SIGUSR1` and `SIGUSR2` (ignored), to gracefully terminate without alarming logs on `SIGTERM`, and to provide a specific log message in case an unhandled signal is received (which causes a shutdown).

Closes #14.