### PR TITLE
Use hmset when renewing auths

### DIFF
--- a/lib/xcflushd/storage.rb
+++ b/lib/xcflushd/storage.rb
@@ -74,9 +74,15 @@ module Xcflushd
       hash_key = hash_key(:auth, service_id, credentials)
 
       authorizations.each_slice(REDIS_BATCH_KEYS) do |authorizations_slice|
+        # Array with the hash key and all the sorted key-values
+        hmset_args = [hash_key]
+
         authorizations_slice.each do |metric, auth|
-          storage.hset(hash_key, metric, auth_value(auth))
+          hmset_args << metric
+          hmset_args << auth_value(auth)
         end
+
+        storage.hmset(*hmset_args)
       end
 
       set_auth_validity(service_id, credentials, auth_ttl)

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -368,7 +368,7 @@ module Xcflushd
 
       context 'when there is an error' do
         # Fake redis error in any method that the client receives.
-        before { allow(redis).to receive(:hset).and_raise(Redis::BaseError) }
+        before { allow(redis).to receive(:hmset).and_raise(Redis::BaseError) }
 
         it "raises a #{renew_auth_error}" do
           expect { subject.renew_auths(service_id, credentials, authorizations, valid_secs) }


### PR DESCRIPTION
This method was too slow. In an AWS machine with 4 cpus renewing all the auths for 1000 apps and 100 metrics each was taking ~15s.

Simply by switching to hmsets, that time is reduced to ~1s.