### PR TITLE
Log waiting time between reporting and renewing auths

### DIFF
--- a/lib/xcflushd/flusher.rb
+++ b/lib/xcflushd/flusher.rb
@@ -54,7 +54,9 @@ module Xcflushd
       # processed.
       # For now, let's just wait a few seconds. This will greatly mitigate the
       # problem.
-      sleep(WAIT_TIME_REPORT_AUTH)
+      run_and_log_time('Giving reports some time to be processed') do
+        sleep(WAIT_TIME_REPORT_AUTH)
+      end
 
       auths = run_and_log_time('Getting the auths from 3scale') do
         authorizations(reports_to_flush)


### PR DESCRIPTION
If the waiting time is not logged, interpreting the logs can be confusing. It looks like the sum of the run time of all the phases of the flusher does not add up.