### PR TITLE
.dockerignore: avoid copying over bundler config directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.bundle


### PR DESCRIPTION
This avoids problems when using some bundler features that create the `.bundle` directory for storing information. Of particular importance when using volumes to share code.