### PR TITLE
Document case where a key is in the set of cached reports but does not exist

### DIFF
--- a/lib/xcflushd/storage.rb
+++ b/lib/xcflushd/storage.rb
@@ -155,8 +155,11 @@ module Xcflushd
           logger.error(SOME_REPORTS_MISSING_ERROR)
         else
           keys.each_with_index do |key, i|
-            # The usage could be empty if we failed to rename the key in the
-            # previous step. hgetall returns {} for keys that do not exist.
+            # hgetall returns {} for keys that do not exist. That can happen
+            # for 2 reasons:
+            # 1) Apicast-xc does not guarantee that a key in the set of cached
+            # reports will always exist.
+            # 2) We failed to rename the key in the previous step.
             unless usages[i].empty?
               service_id, creds = storage_keys.service_and_creds(key, suffix)
               result << { service_id: service_id,


### PR DESCRIPTION
A report in apicast-xc consists of one `hincrby` (increases the usage) and one `sadd` (adds the hash key to the set of cached reports). For performance reasons, those 2 commands are not executed atomically. Therefore, we might find a key in the set that does not exist if a flush was executed between those 2 redis commands. This case should not be treated as an error and this PR adds tests for it.

This behavior was introduced in https://github.com/3scale/apicast-xc/pull/20