### PR TITLE
Providing access to script/launch file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ USER root
 RUN chown -R ${USER_NAME}: ${APP_HOME}
 
 USER ${USER_NAME}
+RUN chmod u+x ${APP_HOME}/script/launch
 RUN bundle install
 
 CMD bundle exec exe/xcflushd run


### PR DESCRIPTION
We are facing issues while running image built using dockerfile. It fails with permission error. Everything works fine after adding below line. 

RUN chmod u+x ${APP_HOME}/script/launch