### PR TITLE
Dockerfile: ensure script and bin files remain executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,10 @@ USER root
 RUN chown -R ${USER_NAME}: ${APP_HOME}
 
 USER ${USER_NAME}
-RUN bundle install
+
+# ensure executable bits are preserved and install dependencies
+RUN find script/ bin/ -maxdepth 1 -type f | xargs chmod +x \
+ && bundle install
 
 ARG JRUBY_EXEC="jruby -Xcompile.invokedynamic=true -J-XX:ReservedCodeCacheSize=256M -J-XX:+UseCodeCacheFlushing -J-Xmn512m -J-Xms2048m -J-Xmx2048m -J-server -J-Djruby.objectspace.enabled=false -J-Djruby.thread.pool.enabled=true -J-Djruby.thread.pool.ttl=600 -J-Djruby.compile.mode=FORCE --server --headless -S"
 CMD ${JRUBY_EXEC} bundle exec exe/xcflushd run


### PR DESCRIPTION
Apparently some environments do not preserve the execution bits.
Whether this is due to git checkouts or docker is unclear at the
moment.

Closes #35.

[alex: use find and rewrite commit message to describe change]