### PR TITLE
Image verification: do not use a plain user as it can break in some setups + clean ups

### DIFF
--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -1,6 +1,6 @@
 FROM fedora:26
 
-RUN dnf install -y make which gnupg2 skopeo && dnf clean all \
+RUN dnf install -y make which gnupg2 skopeo curl && dnf clean all \
  && mkdir -p /opt/app
 
 WORKDIR /opt/app

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -1,10 +1,7 @@
 FROM fedora:26
 
 RUN dnf install -y make which gnupg2 skopeo && dnf clean all \
- && adduser --home /home/user --shell /bin/bash user
+ && mkdir -p /opt/app
 
-USER user
-RUN mkdir /home/user/app
-WORKDIR /home/user/app
-
+WORKDIR /opt/app
 CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ BANNER_LINE = ******************************************************************
 INFO_MARK = [II]
 WARN_MARK = [WW]
 
+DOCKER_VERIFY_RUN := $(DOCKER) run --rm --security-opt label:disable \
+	-v $(PROJECT_PATH):/opt/app -ti $(VERIFY_IMAGE)
+
 default: test
 
 define pinfo
@@ -167,16 +170,18 @@ verify-image:
 
 .PHONY: sign-docker
 sign-docker: verify-image
-	$(DOCKER) run --rm --security-opt label:disable -v $(PROJECT_PATH):/home/user/app -ti $(VERIFY_IMAGE) make TARGET_IMAGE=$(TARGET_IMAGE) MANIFEST=$(MANIFEST) SIGNATURE=$(SIGNATURE) KEY_ID=$(KEY_ID) secret-key sign
+	$(DOCKER_VERIFY_RUN) make TARGET_IMAGE=$(TARGET_IMAGE) MANIFEST=$(MANIFEST) \
+		SIGNATURE=$(SIGNATURE) KEY_ID=$(KEY_ID) secret-key sign
 
 .PHONY: verify-docker
 verify-docker: verify-image
-	$(DOCKER) run --rm --security-opt label:disable -v $(PROJECT_PATH):/home/user/app -ti $(VERIFY_IMAGE) make TARGET_IMAGE=$(TARGET_IMAGE) MANIFEST=$(MANIFEST) SIGNATURE=$(SIGNATURE) KEY_ID=$(KEY_ID) fetch-key verify
+	$(DOCKER_VERIFY_RUN) make TARGET_IMAGE=$(TARGET_IMAGE) MANIFEST=$(MANIFEST) \
+		SIGNATURE=$(SIGNATURE) KEY_ID=$(KEY_ID) fetch-key verify
 
 .PHONY: verify-image-shell
 verify-image-shell: verify-image
 	@echo For this target please define VERIFY_IMAGE_CMD.
-	$(DOCKER) run --rm --security-opt label:disable -v $(PROJECT_PATH):/home/user/app -ti $(VERIFY_IMAGE)
+	$(DOCKER_VERIFY_RUN) $(VERIFY_IMAGE_CMD)
 
 .PHONY: clean-verify-image
 clean-verify-image:


### PR DESCRIPTION
Sharing the project directory with a volume inside the container is
problematic when you want to use an unprivileged user. Apparently
Mac users get a fixed uid/gid combination, and Linux users get the
invoking user's ids. That is a can of worms that requires several
hacks and checks to work correctly. The current solution worked
because it happened to be a coincidence in the uids for single user
machines (ie. uid 1001), but it breaks as soon as you have another
uid invoke it.
    
TL;DR: just use root inside the container to avoid EPERM.