### PR TITLE
Trust key file param & fix TOCTOU issue

### DIFF
--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -1,6 +1,6 @@
 FROM fedora:26
 
-RUN dnf install -y make which gnupg2 skopeo curl && dnf clean all \
+RUN dnf install -y make which gnupg2 skopeo docker curl && dnf clean all \
  && mkdir -p /opt/app
 
 WORKDIR /opt/app

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,15 @@ sign: $(SIGNATURE)
 
 .PHONY: verify
 verify: $(MANIFEST) public-key
+	@if test "x$$(stat -c%s $(MANIFEST))" = "x0"; then \
+		echo "The manifest file $(MANIFEST) looks broken, please remove and retry" >&2 ; \
+		false ; \
+	fi
 	@test -r $(SIGNATURE) || $(MAKE) info fetch-signature
+	@if test "x$$(stat -c%s $(SIGNATURE))" = "x0"; then \
+		echo "The signature file $(SIGNATURE) looks broken, please remove and retry" >&2 ; \
+		false ; \
+	fi
 	# Trying all subkeys
 	@OK=0; for k in $$($(GPG) --list-keys --with-fingerprint --with-fingerprint --with-colons $(KEY_ID) | grep "^fpr:" | cut -d: -f10); do \
 	    echo -n "Checking key $${k}... "; \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GPG ?= $(shell which gpg2 2> /dev/null)
 SKOPEO ?= $(shell which skopeo 2> /dev/null)
 CURL ?= $(shell which curl 2> /dev/null)
 DOCKER ?= $(shell which docker 2> /dev/null)
-TAG ?= $(shell git describe --dirty)
+TAG ?= $(shell git describe --dirty | sed -E -e "s/v([0-9]+.*)/\1/")
 
 REGISTRY ?= registry.hub.docker.com
 REPOSITORY ?= 3scale

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ sign-docker: verify-image
 
 .PHONY: verify-docker
 verify-docker: verify-image
-	$(DOCKER_VERIFY_MAKE) fetch-key verify
+	$(DOCKER_VERIFY_MAKE) verify
 
 .PHONY: verify-image-shell
 verify-image-shell: verify-image

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ INFO_MARK = [II]
 WARN_MARK = [WW]
 
 DOCKER_VERIFY_RUN := $(DOCKER) run --rm --security-opt label:disable \
-	-v $(PROJECT_PATH):/opt/app -ti $(VERIFY_IMAGE)
+	-v $(PROJECT_PATH):/opt/app -v /var/run/docker.sock:/var/run/docker.sock \
+	-ti $(VERIFY_IMAGE)
 # Pass here all variables important for running the make instance inside Docker
 DOCKER_VERIFY_MAKE = $(DOCKER_VERIFY_RUN) make \
 			TAG=$(TAG) DOCKER_REL=$(DOCKER_REL) \

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,12 @@ tag:
 push:
 	$(DOCKER) push $(TARGET_IMAGE)
 
+.PHONY: pull
+pull:
+	if ! $(DOCKER) history --quiet $(TARGET_IMAGE) 2> /dev/null >&2; then \
+		docker pull $(TARGET_IMAGE); \
+	fi
+
 $(MANIFEST):
 	$(SKOPEO) inspect --raw docker://$(TARGET_IMAGE) > $(MANIFEST)
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ verify: $(MANIFEST) public-key
 	# Trying all subkeys
 	@OK=0; for k in $$($(GPG) --list-keys --with-fingerprint --with-fingerprint --with-colons $(KEY_ID) | grep "^fpr:" | cut -d: -f10); do \
 	    echo -n "Checking key $${k}... "; \
-	    if $(SKOPEO) standalone-verify $(MANIFEST) $(TARGET_IMAGE) $${k} $(SIGNATURE) 2> /dev/null; then \
+	    if $(SKOPEO) standalone-verify $(MANIFEST) $(TARGET_IMAGE) $${k} $(SIGNATURE) 2>> /tmp/skopeo-err; then \
 	        OK=1; \
 	        break; \
 	    else \
@@ -185,8 +185,12 @@ verify: $(MANIFEST) public-key
 	done; \
 	if test "x$${OK}" = "x1"; then \
 	    echo -e "\n$(BANNER_LINE)\n$(INFO_MARK) Signature verification OK\n$(BANNER_LINE)"; \
+		rm /tmp/skopeo-err; \
 	else \
 	    echo -e "\n$(BANNER_LINE)\n$(WARN_MARK) Signature verification FAILED\n$(BANNER_LINE)"; \
+		echo -e "\nError output:\n"; \
+		cat /tmp/skopeo-err; \
+		rm /tmp/skopeo-err; \
 	    false; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,12 @@ The command you want to run for verifying the Docker release 1 of v1.2.1 is:
 > make TAG=1.2.1 DOCKER_REL=1 verify-docker
 
 You could also specify a particular `KEY_ID` to check against.
-Run `make info` to get information about other variables.
+
+If you have a key file with name "<KEY_ID>.asc" in the project's root directory
+it can be imported into the keyring (provided it is not there already) by using
+the parameter `TRUST_KEY_FILE=1`.
+
+Run `make info` to get the current values of these and other variables.
 
 #### Signing The Easy Way
 


### PR DESCRIPTION
The default behaviour when verifying images has changed so that:

* The `<KEY_ID>.asc` file is not trusted by default (ie. so the public key is fetched).
* The image is pulled before trying to verify it to avoid a TOCTOU issue.

You can specify `TRUST_KEY_FILE=1` to try to import the signing key from a file before verification, and you can specify `DOWNLOAD_IMAGE=0` to verify the image uploaded to Docker Hub as opposed to the locally downloaded image (this is strongly discouraged, as the image is downloaded from Docker Hub already and there is a time window between the moment you verify and the moment you download the image in which it could potentially be modified, google `TOCTOU`).